### PR TITLE
[ performance ] add stack item for Attempt

### DIFF
--- a/examples/profile.txt
+++ b/examples/profile.txt
@@ -93,90 +93,90 @@ NUC:
 Lenovo:
 1 thread
 
-  Alloc:          31 s 974 ms 595 us 649 ns
-  Async2:         0 us 399 ns
-  Bind:           0 us 13 ns
-  Chained Spawn:  0 us 140 ns
-  Consumers:      10 us 452 ns
-  Par Traverse:   2 us 835 ns
-  Ping Pong:      0 us 999 ns
-  Race (trivial): 0 us 661 ns
-  Race (single):  0 us 873 ns
-  Race (both):    1 us 137 ns
-  Scheduling:     33 s 333 ms 385 us 283 ns
-  Spawn:          0 us 186 ns
+  Alloc:          31 s 706 ms 828 us 98 ns
+  Async2:         0 us 360 ns
+  Bind:           0 us 12 ns
+  Chained Spawn:  0 us 130 ns
+  Consumers:      10 us 144 ns
+  Par Traverse:   2 us 633 ns
+  Ping Pong:      0 us 933 ns
+  Race (trivial): 0 us 648 ns
+  Race (single):  0 us 849 ns
+  Race (both):    1 us 112 ns
+  Scheduling:     25 s 707 ms 624 us 753 ns
+  Spawn:          0 us 173 ns
 
 2 threads
 
-  Alloc:          17 s 541 ms 851 us 968 ns
-  Async2:         0 us 415 ns
+  Alloc:          17 s 342 ms 848 us 776 ns
+  Async2:         0 us 391 ns
   Bind:           0 us 13 ns
-  Chained Spawn:  0 us 151 ns
-  Consumers:      12 us 11 ns
-  Par Traverse:   2 us 878 ns
-  Ping Pong:      1 us 252 ns
-  Race (trivial): 0 us 680 ns
-  Race (single):  0 us 887 ns
-  Race (both):    1 us 173 ns
-  Scheduling:     21 s 727 ms 761 us 823 ns
-  Spawn:          0 us 243 ns
+  Chained Spawn:  0 us 145 ns
+  Consumers:      8 us 929 ns
+  Par Traverse:   2 us 879 ns
+  Ping Pong:      1 us 199 ns
+  Race (trivial): 0 us 662 ns
+  Race (single):  0 us 902 ns
+  Race (both):    1 us 245 ns
+  Scheduling:     18 s 459 ms 221 us 804 ns
+  Spawn:          0 us 221 ns
 
 4 threads
 
-  Alloc:          12 s 85 ms 556 us 218 ns
-  Async2:         0 us 460 ns
+  Alloc:          12 s 111 ms 329 us 172 ns
+  Async2:         0 us 428 ns
   Bind:           0 us 13 ns
-  Chained Spawn:  0 us 165 ns
-  Consumers:      11 us 65 ns
-  Par Traverse:   3 us 114 ns
-  Ping Pong:      1 us 361 ns
-  Race (trivial): 0 us 682 ns
-  Race (single):  0 us 953 ns
-  Race (both):    1 us 354 ns
-  Scheduling:     13 s 865 ms 483 us 896 ns
-  Spawn:          0 us 281 ns
+  Chained Spawn:  0 us 154 ns
+  Consumers:      11 us 271 ns
+  Par Traverse:   2 us 984 ns
+  Ping Pong:      1 us 279 ns
+  Race (trivial): 0 us 630 ns
+  Race (single):  0 us 943 ns
+  Race (both):    1 us 419 ns
+  Scheduling:     13 s 542 ms 215 us 857 ns
+  Spawn:          0 us 271 ns
 
 8 threads
 
-  Alloc:          10 s 228 ms 978 us 20 ns
-  Async2:         0 us 534 ns
+  Alloc:          9 s 580 ms 722 us 339 ns
+  Async2:         0 us 483 ns
   Bind:           0 us 13 ns
-  Chained Spawn:  0 us 192 ns
-  Consumers:      12 us 312 ns
-  Par Traverse:   3 us 113 ns
-  Ping Pong:      1 us 330 ns
-  Race (trivial): 0 us 701 ns
-  Race (single):  1 us 77 ns
-  Race (both):    1 us 564 ns
-  Scheduling:     11 s 775 ms 751 us 314 ns
-  Spawn:          0 us 309 ns
+  Chained Spawn:  0 us 181 ns
+  Consumers:      11 us 92 ns
+  Par Traverse:   3 us 75 ns
+  Ping Pong:      1 us 283 ns
+  Race (trivial): 0 us 655 ns
+  Race (single):  1 us 83 ns
+  Race (both):    1 us 614 ns
+  Scheduling:     10 s 559 ms 570 us 453 ns
+  Spawn:          0 us 279 ns
 
 16 threads
 
-  Alloc:          11 s 534 ms 25 us 40 ns
-  Async2:         0 us 580 ns
+  Alloc:          11 s 202 ms 947 us 446 ns
+  Async2:         0 us 526 ns
   Bind:           0 us 14 ns
-  Chained Spawn:  0 us 201 ns
-  Consumers:      12 us 231 ns
-  Par Traverse:   3 us 188 ns
-  Ping Pong:      1 us 385 ns
-  Race (trivial): 0 us 696 ns
-  Race (single):  1 us 224 ns
-  Race (both):    1 us 714 ns
-  Scheduling:     12 s 368 ms 495 us 111 ns
-  Spawn:          0 us 303 ns
+  Chained Spawn:  0 us 198 ns
+  Consumers:      11 us 566 ns
+  Par Traverse:   2 us 980 ns
+  Ping Pong:      1 us 233 ns
+  Race (trivial): 0 us 648 ns
+  Race (single):  1 us 180 ns
+  Race (both):    1 us 696 ns
+  Scheduling:     10 s 433 ms 782 us 111 ns
+  Spawn:          0 us 286 ns
 
 32 threads
 
-  Alloc:          14 s 227 ms 137 us 888 ns
-  Async2:         0 us 516 ns
+  Alloc:          13 s 895 ms 457 us 463 ns
+  Async2:         0 us 472 ns
   Bind:           0 us 14 ns
-  Chained Spawn:  0 us 166 ns
-  Consumers:      13 us 33 ns
-  Par Traverse:   3 us 353 ns
-  Ping Pong:      1 us 403 ns
-  Race (trivial): 0 us 738 ns
-  Race (single):  1 us 89 ns
-  Race (both):    1 us 526 ns
-  Scheduling:     12 s 826 ms 633 us 166 ns
-  Spawn:          0 us 303 ns
+  Chained Spawn:  0 us 167 ns
+  Consumers:      14 us 210 ns
+  Par Traverse:   3 us 300 ns
+  Ping Pong:      1 us 294 ns
+  Race (trivial): 0 us 682 ns
+  Race (single):  1 us 102 ns
+  Race (both):    1 us 537 ns
+  Scheduling:     11 s 694 ms 687 us 684 ns
+  Spawn:          0 us 282 ns


### PR DESCRIPTION
By disentangling error handling from monadic bind on the async stack, things get both a bit simpler and a couple of percents faster.