### PR TITLE
Support additional signals via default implicit

### DIFF
--- a/async-epoll/src/IO/Async/Loop/Epoll.idr
+++ b/async-epoll/src/IO/Async/Loop/Epoll.idr
@@ -210,12 +210,21 @@ epollPoller t =
 |||
 ||| We use environment variable `IDRIS2_ASYNC_THREADS` to determine the
 ||| number of threads to use (default: 2) and cancel the running program
-||| on receiving `SIGINT`. Other signals are not supported.
+||| on receiving `SIGINT`.
+|||
+||| By default, only `SIGINT` is masked. To handle other signals
+||| within your program, give `{sigs = [...]}` as the first
+||| argument. One of the signals must be SIGINT, which is enforced by
+||| the `Has SIGINT sigs` constraint.
 export covering
-epollApp : Async Poll [] () -> IO ()
-epollApp prog = do
+epollApp
+  : {default [SIGINT] sigs : List Signal}
+  -> Has SIGINT sigs
+  => Async Poll [] ()
+  -> IO ()
+epollApp {sigs} prog = do
   n <- asyncThreads
-  app n [SIGINT] epollPoller cprog
+  app n sigs epollPoller cprog
 
   where
     cprog : Async Poll [] ()

--- a/async-posix/src/IO/Async/Loop/Posix.idr
+++ b/async-posix/src/IO/Async/Loop/Posix.idr
@@ -350,12 +350,21 @@ asyncThreads = do
 |||
 ||| We use environment variable `IDRIS2_ASYNC_THREADS` to determine the
 ||| number of threads to use (default: 2) and cancel the running program
-||| on receiving `SIGINT`. Other signals are not supported.
+||| on receiving `SIGINT`.
+|||
+||| By default, only `SIGINT` is masked, to handle other signals
+||| within your program, give `{sigs = [...]}` as the first
+||| argument. One of the signals must be SIGINT, which is enforced by
+||| the `Has SIGINT sigs` constraint.
 export covering
-simpleApp : Async Poll [] () -> IO ()
-simpleApp prog = do
+simpleApp
+  : {default [SIGINT] sigs : List Signal}
+  -> Has SIGINT sigs
+  => Async Poll [] ()
+  -> IO ()
+simpleApp {sigs} prog = do
   n <- asyncThreads
-  app n [SIGINT] posixPoller cprog
+  app n sigs posixPoller cprog
 
   where
     cprog : Async Poll [] ()


### PR DESCRIPTION
I realized there was an easy way to support additional signals that hopefully won't break existing code.